### PR TITLE
pyviz_comms 2.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.0" %}
+{% set version = "2.2.1" %}
 
 package:
   name: pyviz_comms
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pyviz_comms/pyviz_comms-{{ version }}.tar.gz
-  sha256: f4a7126f318fb6b964fef3f92fa55bc46b9218f62a8464a8b18e968b3087dbc0
+  sha256: a26145b8ce43d2d934b3c6826d77b913ce105c528eb2e494c890b3e3525ddf33
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index dc60b73..a6909c0 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.0" %}
+{% set version = "2.2.1" %}
 
 package:
   name: pyviz_comms
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pyviz_comms/pyviz_comms-{{ version }}.tar.gz
-  sha256: f4a7126f318fb6b964fef3f92fa55bc46b9218f62a8464a8b18e968b3087dbc0
+  sha256: a26145b8ce43d2d934b3c6826d77b913ce105c528eb2e494c890b3e3525ddf33
 
 build:
   number: 0

```

**Jira ticket:** [PKG-302](https://anaconda.atlassian.net/browse/PKG-302) (pyviz_comms-2.2.1)

**The upstream data:**
Github releases:  https://github.com/holoviz/pyviz_comms/releases
[Diff between the latest and previous upstream releases](https://github.com/holoviz/pyviz_comms/compare/2.0.2...2.2.1)
Requirements:
 * setup.py:  https://github.com/holoviz/pyviz_comms/blob/v2.2.1/setup.py
 *  pyproject.toml:  https://github.com/holoviz/pyviz_comms/blob/v2.2.1/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: easy | Category: anaconda_affiliated | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2.2.1
 * Release on PyPi:
    * version: 2.2.1
    * date: 2022-08-18T23:43:14
* [PyPi history](https://pypi.org/project/pyviz_comms/#history)
 * Popularity: 
    * 3 months downloads: 180520.0
    * All time:  754195 downloads -  pyviz_comms  2.2.1  Bidirectional communication for PyViz  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE.txt is present

14. - [x] license_family BSD is present
16. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |
</details>

**Check dependency issues:**

<details>
../aggregate/pyviz_comms-feedstock/recipe/meta.yaml
Dependencies: ['pip', 'jupyterlab >=3.0', 'wheel', 'notebook', 'twine', 'setuptools', 'python >=2.7', 'keyring', 'param', 'rfc3986', 'jupyter-packaging >=0.7.9']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  Encountered problems while solving:
  - nothing provides readme_renderer >=21.0 needed by twine-1.13.0-py_1

- py3.8:  Encountered problems while solving:
  - nothing provides readme_renderer >=21.0 needed by twine-1.13.0-py_1

- py3.9:  Encountered problems while solving:
  - nothing provides readme_renderer >=21.0 needed by twine-1.13.0-py_1

- py3.10:  Encountered problems while solving:
  - nothing provides readme_renderer >=21.0 needed by twine-1.13.0-py_1


osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 19**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/pyviz_comms-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/pyviz_comms-feedstock/tree/2.2.1)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/pyviz_comms)
* [Diff between upstream and feature branch](https://github.com/conda-forge/pyviz_comms-feedstock/compare/main...AnacondaRecipes:2.2.1)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/pyviz_comms-feedstock/compare/master...AnacondaRecipes:2.2.1)
* [The last merged PRs](https://github.com/AnacondaRecipes/pyviz_comms-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2.2.1 git@github.com:AnacondaRecipes/pyviz_comms-feedstock.git
```


[PKG-302]: https://anaconda.atlassian.net/browse/PKG-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ