### PR TITLE
Bump to version 3.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.0" %}
+{% set version = "3.0.2" %}
 
 package:
   name: pyviz_comms
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pyviz_comms/pyviz_comms-{{ version }}.tar.gz
-  sha256: f4ca91e4157a64e3abed7cc249e60b9a8d2532f8832f1cb075914d19337d2ba6
+  sha256: 3167df932656416c4bd711205dad47e986a3ebae1f316258ddc26f9e01513ef7
 
 build:
   number: 0


### PR DESCRIPTION
pyviz_comms 3.0.2

**Destination channel:** defaults

### Explanation of changes:

Very simple version bump to 3.0.2.

This new version is required to roll out a new dashboard builder UI in Anaconda.cloud and DSP.